### PR TITLE
[FEAT] Product 바운디드-컨텍스트 기본 구조 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/core/src/main/java/io/devground/core/model/entity/BaseEntity.java
+++ b/core/src/main/java/io/devground/core/model/entity/BaseEntity.java
@@ -36,7 +36,7 @@ public abstract class BaseEntity {
 	private LocalDateTime updatedAt = LocalDateTime.now();
 
 	@PrePersist
-	protected void onCellCreated() {
+	protected void onCreate() {
 		if (this.createdAt == null)
 			this.createdAt = LocalDateTime.now();
 

--- a/core/src/main/java/io/devground/core/model/vo/ErrorCode.java
+++ b/core/src/main/java/io/devground/core/model/vo/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
 
 	// product
 	PRODUCT_NOT_FOUND(404, "상품을 찾을 수 없습니다."),
+	ONLY_ON_SALE_PRODUCT_CHANGEABLE(400, "판매 중인 상품만 판매 완료 처리할 수 있습니다."),
+	SOLD_PRODUCT_CANNOT_UPDATE(400, "이미 판매된 상품 내용은 변경할 수 없습니다."),
 
 	// image
 	IMAGE_NOT_FOUND(404, "이미지를 찾을 수 없습니다.");

--- a/src/main/java/io/devground/dbay/domain/product/category/entity/Category.java
+++ b/src/main/java/io/devground/dbay/domain/product/category/entity/Category.java
@@ -1,0 +1,60 @@
+package io.devground.dbay.domain.product.category.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.devground.core.model.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "parentId")
+	private Category parentCategory;
+
+	@OneToMany(mappedBy = "parentCategory", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Category> children = new ArrayList<>();
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false)
+	private Integer depth = 1;
+
+	@Builder
+	public Category(Category parent, String name, Integer depth) {
+		this.parentCategory = parent;
+		this.name = name;
+		this.depth = depth != null ? depth : 1;
+	}
+
+	public void addChildren(Category children) {
+		this.children.add(children);
+		children.parentCategory = this;
+	}
+
+	public void removeChildren(Category children) {
+		this.children.remove(children);
+		children.parentCategory = null;
+	}
+}

--- a/src/main/java/io/devground/dbay/domain/product/category/repository/CategoryRepository.java
+++ b/src/main/java/io/devground/dbay/domain/product/category/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package io.devground.dbay.domain.product.category.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.devground.dbay.domain.product.category.entity.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/io/devground/dbay/domain/product/product/controller/ProductController.java
+++ b/src/main/java/io/devground/dbay/domain/product/product/controller/ProductController.java
@@ -1,0 +1,15 @@
+package io.devground.dbay.domain.product.product.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.devground.dbay.domain.product.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/products")
+public class ProductController {
+
+	private final ProductService productService;
+}

--- a/src/main/java/io/devground/dbay/domain/product/product/entity/Product.java
+++ b/src/main/java/io/devground/dbay/domain/product/product/entity/Product.java
@@ -1,0 +1,50 @@
+package io.devground.dbay.domain.product.product.entity;
+
+import io.devground.core.model.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Lob
+	@Column(nullable = false)
+	private String description;
+
+	@OneToOne(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+	private ProductSale productSale;
+
+	@Builder
+	public Product(String title, String description) {
+		this.title = title;
+		this.description = description;
+	}
+
+	public void addProductSale(ProductSale productSale) {
+		this.productSale = productSale;
+	}
+
+	public void changeProductInfo(String title, String description) {
+		this.title = title;
+		this.description = description;
+	}
+}

--- a/src/main/java/io/devground/dbay/domain/product/product/entity/ProductSale.java
+++ b/src/main/java/io/devground/dbay/domain/product/product/entity/ProductSale.java
@@ -1,0 +1,79 @@
+package io.devground.dbay.domain.product.product.entity;
+
+import java.time.LocalDateTime;
+
+import io.devground.core.model.entity.BaseEntity;
+import io.devground.core.model.vo.ErrorCode;
+import io.devground.dbay.domain.product.product.vo.ProductStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductSale extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne
+	@JoinColumn(name = "productId", nullable = false, unique = true)
+	private Product product;
+
+	@Column(nullable = false)
+	private String sellerCode;
+
+	@Column(nullable = false)
+	private Long price;
+
+	@Enumerated(EnumType.STRING)
+	private ProductStatus productStatus;
+
+	private LocalDateTime soldAt;
+
+	@Builder
+	public ProductSale(String sellerCode, Long price, Product product) {
+		this.sellerCode = sellerCode;
+		this.price = price;
+		this.product = product;
+		this.productStatus = ProductStatus.ON_SALE;
+	}
+
+	public void addProduct(Product product) {
+		this.product = product;
+		product.addProductSale(this);
+	}
+
+	public void changeAsSold() {
+		if (isSold()) {
+			throw ErrorCode.ONLY_ON_SALE_PRODUCT_CHANGEABLE.throwServiceException();
+		}
+
+		this.productStatus = ProductStatus.SOLD;
+		this.soldAt = LocalDateTime.now();
+	}
+
+	public void changePrice(Long price) {
+		if (isSold()) {
+			throw ErrorCode.SOLD_PRODUCT_CANNOT_UPDATE.throwServiceException();
+		}
+
+		this.price = price;
+	}
+
+	public boolean isSold() {
+		return this.productStatus == ProductStatus.ON_SALE;
+	}
+}

--- a/src/main/java/io/devground/dbay/domain/product/product/repository/ProductRepository.java
+++ b/src/main/java/io/devground/dbay/domain/product/product/repository/ProductRepository.java
@@ -1,0 +1,8 @@
+package io.devground.dbay.domain.product.product.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.devground.dbay.domain.product.product.entity.Product;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/io/devground/dbay/domain/product/product/repository/ProductSaleRepository.java
+++ b/src/main/java/io/devground/dbay/domain/product/product/repository/ProductSaleRepository.java
@@ -1,0 +1,8 @@
+package io.devground.dbay.domain.product.product.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.devground.dbay.domain.product.product.entity.ProductSale;
+
+public interface ProductSaleRepository extends JpaRepository<ProductSale, Long> {
+}

--- a/src/main/java/io/devground/dbay/domain/product/product/service/ProductService.java
+++ b/src/main/java/io/devground/dbay/domain/product/product/service/ProductService.java
@@ -1,0 +1,4 @@
+package io.devground.dbay.domain.product.product.service;
+
+public interface ProductService {
+}

--- a/src/main/java/io/devground/dbay/domain/product/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/io/devground/dbay/domain/product/product/service/impl/ProductServiceImpl.java
@@ -1,0 +1,20 @@
+package io.devground.dbay.domain.product.product.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import io.devground.dbay.domain.product.category.repository.CategoryRepository;
+import io.devground.dbay.domain.product.product.repository.ProductRepository;
+import io.devground.dbay.domain.product.product.repository.ProductSaleRepository;
+import io.devground.dbay.domain.product.product.service.ProductService;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+
+@Service
+@Transactional
+@AllArgsConstructor
+public class ProductServiceImpl implements ProductService {
+
+	private final ProductRepository productRepository;
+	private final ProductSaleRepository productSaleRepository;
+	private final CategoryRepository categoryRepository;
+}

--- a/src/main/java/io/devground/dbay/domain/product/product/vo/ProductStatus.java
+++ b/src/main/java/io/devground/dbay/domain/product/product/vo/ProductStatus.java
@@ -1,0 +1,13 @@
+package io.devground.dbay.domain.product.product.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ProductStatus {
+	ON_SALE("판매 중"),
+	SOLD("판매 완료");
+
+	private final String value;
+}


### PR DESCRIPTION
## 📌 PR 요약
- Product 바운디드-컨텍스트 내 도메인 기본 구조 작성

## 🔍 관련 이슈
- close #6 

## 🧩 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 💡 참고 사항
- Product, ProductSale, Category 도메인의 기본 구조를 작성하였습니다.
- annotationProcessor에 lombok 의존성 추가하였습니다.
- 기존 BaseEntity에 등록된 메서드 오탈자 수정했습니다.