### PR TITLE
[FEAT]장바구니 생성 기능 추가

### DIFF
--- a/core/src/main/java/io/devground/core/model/vo/ErrorCode.java
+++ b/core/src/main/java/io/devground/core/model/vo/ErrorCode.java
@@ -11,11 +11,15 @@ public enum ErrorCode {
 	// server
 	INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),
 
+	// common
+	CODE_INVALID(400, "잘못된 코드 형식입니다."),
+
 	// user/auth
 	UNAUTHORIZED(401, "로그인이 필요합니다."),
 	USER_NOT_FOUNT(404, "사용자를 찾을 수 없습니다."),
 
 	// cart
+	CART_ALREADY_EXIST(409, "장바구니가 이미 존재합니다."),
 	CART_NOT_FOUND(404, "장바구니를 찾을 수 없습니다."),
 
 	// order

--- a/core/src/main/java/io/devground/core/util/Validators.java
+++ b/core/src/main/java/io/devground/core/util/Validators.java
@@ -1,0 +1,20 @@
+package io.devground.core.util;
+
+import java.util.UUID;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class Validators {
+	// UUID 포맷 검증을 위한 공통 메서드
+	public boolean isValidUuid(String code) {
+		if (code == null)
+			return false;
+		try {
+			UUID.fromString(code);
+			return true;
+		} catch (IllegalArgumentException e) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/io/devground/dbay/domain/cart/cart/model/entity/Cart.java
+++ b/src/main/java/io/devground/dbay/domain/cart/cart/model/entity/Cart.java
@@ -3,6 +3,8 @@ package io.devground.dbay.domain.cart.cart.model.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.util.StringUtils;
+
 import io.devground.core.model.entity.BaseEntity;
 import io.devground.core.model.vo.ErrorCode;
 import io.devground.dbay.domain.cart.cartItem.model.entity.CartItem;
@@ -33,7 +35,7 @@ public class Cart extends BaseEntity {
 
 	@Builder
 	public Cart(String userCode) {
-		if (userCode == null || userCode.isBlank()) {
+		if (!StringUtils.hasText(userCode)) {
 			throw ErrorCode.CART_NOT_FOUND.throwServiceException();
 		}
 		this.userCode = userCode;

--- a/src/main/java/io/devground/dbay/domain/cart/cart/repository/CartRepository.java
+++ b/src/main/java/io/devground/dbay/domain/cart/cart/repository/CartRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import io.devground.dbay.domain.cart.cart.model.entity.Cart;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
+	boolean existsByUserCode(String userCode);
 }

--- a/src/main/java/io/devground/dbay/domain/cart/cart/service/CartService.java
+++ b/src/main/java/io/devground/dbay/domain/cart/cart/service/CartService.java
@@ -1,4 +1,7 @@
 package io.devground.dbay.domain.cart.cart.service;
 
+import io.devground.dbay.domain.cart.cart.model.entity.Cart;
+
 public interface CartService {
+	Cart createCart(String userCode);
 }

--- a/src/main/java/io/devground/dbay/domain/cart/cart/service/CartServiceImpl.java
+++ b/src/main/java/io/devground/dbay/domain/cart/cart/service/CartServiceImpl.java
@@ -1,4 +1,38 @@
 package io.devground.dbay.domain.cart.cart.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.devground.core.model.vo.ErrorCode;
+import io.devground.core.util.Validators;
+import io.devground.dbay.domain.cart.cart.model.entity.Cart;
+import io.devground.dbay.domain.cart.cart.repository.CartRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class CartServiceImpl implements CartService {
+
+	private final CartRepository cartRepository;
+
+	@Override
+	@Transactional
+	public Cart createCart(String userCode) {
+
+		if (!Validators.isValidUuid(userCode)) {
+			throw ErrorCode.CODE_INVALID.throwServiceException();
+		}
+
+		if (cartRepository.existsByUserCode(userCode)) {
+			throw ErrorCode.CART_ALREADY_EXIST.throwServiceException();
+		}
+
+		Cart cart = Cart.builder()
+			.userCode(userCode)
+			.build();
+
+		// deposit에 kafka 이벤트 전달
+
+		return cartRepository.save(cart);
+	}
 }

--- a/src/main/java/io/devground/dbay/domain/cart/cartItem/model/entity/CartItem.java
+++ b/src/main/java/io/devground/dbay/domain/cart/cartItem/model/entity/CartItem.java
@@ -1,5 +1,7 @@
 package io.devground.dbay.domain.cart.cartItem.model.entity;
 
+import org.springframework.util.StringUtils;
+
 import io.devground.core.model.entity.BaseEntity;
 import io.devground.core.model.exception.ServiceException;
 import io.devground.core.model.vo.ErrorCode;
@@ -37,7 +39,7 @@ public class CartItem extends BaseEntity {
 			throw new ServiceException(ErrorCode.CART_NOT_FOUND);
 		}
 
-		if (productCode == null || productCode.isBlank()) {
+		if (!StringUtils.hasText(productCode)) {
 			throw ErrorCode.CART_NOT_FOUND.throwServiceException();
 		}
 

--- a/src/main/java/io/devground/dbay/domain/order/order/model/entity/Order.java
+++ b/src/main/java/io/devground/dbay/domain/order/order/model/entity/Order.java
@@ -3,6 +3,8 @@ package io.devground.dbay.domain.order.order.model.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.util.StringUtils;
+
 import io.devground.core.model.entity.BaseEntity;
 import io.devground.core.model.vo.ErrorCode;
 import io.devground.dbay.domain.order.order.model.vo.OrderStatus;
@@ -49,15 +51,15 @@ public class Order extends BaseEntity {
 
 	@Builder
 	public Order(String userCode, String nickName, String address, Long totalAmount) {
-		if (userCode == null || userCode.isBlank()) {
+		if (!StringUtils.hasText(userCode)) {
 			throw ErrorCode.USER_NOT_FOUNT.throwServiceException();
 		}
 
-		if (nickName == null || nickName.isBlank()) {
+		if (!StringUtils.hasText(nickName)) {
 			throw ErrorCode.USER_NOT_FOUNT.throwServiceException();
 		}
 
-		if (address == null || address.isBlank()) {
+		if (!StringUtils.hasText(address)) {
 			throw ErrorCode.ADDRESS_NOT_FOUND.throwServiceException();
 		}
 

--- a/src/test/java/io/devground/dbay/domain/cart/service/CartServiceImplTest.java
+++ b/src/test/java/io/devground/dbay/domain/cart/service/CartServiceImplTest.java
@@ -1,0 +1,71 @@
+package io.devground.dbay.domain.cart.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.devground.core.model.exception.ServiceException;
+import io.devground.core.model.vo.ErrorCode;
+import io.devground.dbay.domain.cart.cart.model.entity.Cart;
+import io.devground.dbay.domain.cart.cart.repository.CartRepository;
+import io.devground.dbay.domain.cart.cart.service.CartServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+class CartServiceImplTest {
+
+	@Mock
+	private CartRepository cartRepository;
+
+	@InjectMocks
+	private CartServiceImpl cartService;
+
+	@Test
+	void createCart_success() {
+
+		String userCode = UUID.randomUUID().toString();
+		given(cartRepository.existsByUserCode(userCode)).willReturn(false);
+
+		Cart cart = Cart.builder()
+			.userCode(userCode)
+			.build();
+		given(cartRepository.save(any(Cart.class))).willReturn(cart);
+
+		Cart result = cartService.createCart(userCode);
+
+		assertThat(result.getUserCode()).isEqualTo(userCode);
+		verify(cartRepository).existsByUserCode(userCode);
+		verify(cartRepository).save(any(Cart.class));
+	}
+
+	@Test
+	void createCart_throwException_whenInvalidCode() {
+		String userCode = "invalid-code";
+
+		assertThatThrownBy(() -> cartService.createCart(userCode))
+			.isInstanceOf(ServiceException.class)
+			.satisfies(ex -> {
+				ServiceException se = (ServiceException) ex;
+				assertThat(se.getErrorCode()).isEqualTo(ErrorCode.CODE_INVALID);
+			});
+	}
+
+	@Test
+	void createCart_throwException_whenCartAlreadyExists() {
+		String userCode = UUID.randomUUID().toString();
+		given(cartRepository.existsByUserCode(userCode)).willReturn(true);
+
+		assertThatThrownBy(() -> cartService.createCart(userCode))
+			.isInstanceOf(ServiceException.class)
+			.satisfies(ex -> {
+				ServiceException se = (ServiceException) ex;
+				assertThat(se.getErrorCode()).isEqualTo(ErrorCode.CART_ALREADY_EXIST);
+			});
+	}
+}


### PR DESCRIPTION
## 📌 PR 요약
장바구니 생성 기능
장바구니 생성 테스트 코드 작성

## 🔍 관련 이슈
- close #20

## 🧩 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 💡 참고 사항
UUID 검증 로직이 필요할거같아 core 모듈에 util패키지를 추가하여 공통 메서드를 추가하였습니다.
장바구니는 회원가입시 자동생성되므로 컨트롤러 API에 추가하지 않았습니다.