### PR TITLE
[REFACTOR] 장바구니 상품 삭제 hardDelete 변경

### DIFF
--- a/src/main/java/io/devground/dbay/domain/cart/cartItem/repository/CartItemRepository.java
+++ b/src/main/java/io/devground/dbay/domain/cart/cartItem/repository/CartItemRepository.java
@@ -17,9 +17,7 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
 	@Modifying
 	@Query("""
-		UPDATE CartItem ci
-		SET ci.deleteStatus = 'Y',
-			ci.updatedAt = CURRENT_TIMESTAMP
+		DELETE FROM CartItem ci
 		WHERE ci.cart = :cart
 			AND ci.deleteStatus = 'N'
 			AND ci.productCode IN :cartProductCodes
@@ -29,10 +27,8 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
 	@Modifying
 	@Query("""
-		UPDATE CartItem ci
-			SET ci.deleteStatus = 'Y',
-				ci.updatedAt = CURRENT_TIMESTAMP
-			WHERE ci.cart = :cart
+		DELETE FROM CartItem ci
+		WHERE ci.cart = :cart
 		""")
 	void deleteCartItemByCartCode(@Param("cart") Cart cart);
 

--- a/src/test/java/io/devground/dbay/domain/cart/CartIntegrationTest.java
+++ b/src/test/java/io/devground/dbay/domain/cart/CartIntegrationTest.java
@@ -1,15 +1,13 @@
 package io.devground.dbay.domain.cart;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.List;
+import java.util.UUID;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -171,8 +169,7 @@ public class CartIntegrationTest {
 
 		assertThat(result).isEqualTo(2);
 		assertThat(cartItems)
-			.filteredOn(item -> DeleteStatus.Y.equals(item.getDeleteStatus()))
-			.hasSize(2);
+			.hasSize(0);
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 PR 요약
장바구니 삭제시 데이터 삭제로 변경

## 🔍 관련 이슈
- close #106 

## 🧩 변경 사항
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 💡 참고 사항