### PR TITLE
[FIX] KafkaErrorhandler 중복 호출 제거

### DIFF
--- a/src/main/java/io/devground/dbay/common/saga/repository/SagaRepository.java
+++ b/src/main/java/io/devground/dbay/common/saga/repository/SagaRepository.java
@@ -35,10 +35,10 @@ public interface SagaRepository extends JpaRepository<Saga, Long> {
 		AND s.startedAt < :startedAt
 		AND s.sagaStatus = 'IN_PROCESS'
 		""")
-	List<Saga> findSagaByCurrentStepInAndStartedAtBefore(
+	List<Saga> findSagasByCurrentStepInAndStartedAtBefore(
 		@Param("steps") List<SagaStep> steps,
 		@Param("startedAt") LocalDateTime startedAt
 	);
 
-	List<Saga> findSagaBySagaStatusAndUpdatedAtBefore(SagaStatus sagaStatus, LocalDateTime updatedAt);
+	List<Saga> findAllBySagaStatusInAndUpdatedAtBefore(List<SagaStatus> sagaStatus, LocalDateTime updatedAt);
 }

--- a/src/main/java/io/devground/dbay/domain/image/infra/kafka/ImageKafkaProducer.java
+++ b/src/main/java/io/devground/dbay/domain/image/infra/kafka/ImageKafkaProducer.java
@@ -11,13 +11,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ImageKafkaProducer {
 
-	private final KafkaTemplate<String, Object> kafkaTemplate;
-	private final ImageTopicProperties imageTopicProperties;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ImageTopicProperties imageTopicProperties;
 
-	public void publishImageProcessed(ImageProcessedEvent event) {
+    public void publishImageProcessed(ImageProcessedEvent event) {
 
-		String topic = imageTopicProperties.getProcessed();
-		kafkaTemplate.send(topic, event.sagaId(), event);
-	}
+        String topic = imageTopicProperties.getProcessed();
+        kafkaTemplate.send(topic, event.sagaId(), event);
+    }
 
 }


### PR DESCRIPTION
## 📌 PR 요약
### 1. 현재 구조는 DLT 토픽에서 예외 발생 시 또 KafkaErrorHandler에 의해 재시도 시도
- 각 DLT리스너들의 예외를 catch로 잡아주어, DLT 재시도 모두 실패는 최종 실패로 마무리
### 2. ImageScheduledProcessor에서 DLT 최종 실패 Saga 또한 Fail로 업데이트 처리
  - SagaStatus.FAIL 은 수동 처리 필요
### 3. Kafka 통신 시의 전체적인 예외 버그 처리
### 4. ProductImageSagaOrchestrator의 최종 이미지 처리 실패 예외 처리 추가
  - 최종 이미지 처리 실패 시 로깅 및 SagaStatus를 Fail로 업데이트

## 🧩 변경 사항
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 💡 참고 사항
- `KafkaErrorHandler` 가 중복 재귀적으로 호출되는 버그를 수정하였습니다.
- `DLT` 토픽 처리는 관련 **Saga 스케쥴러**가 `SagaStatus` 를 `FAIL` 로 변경하도록 구현하였습니다.
  - `SagaStatus.FAIL` 의 경우, 수동 처리가 필요합니다.