### PR TITLE
[FIX] 이메일 인증 예외 처리 중 에러를 던지지 않아 정상 흐름으로 진행되던 것 수정

### DIFF
--- a/user/src/main/java/com/example/user/controller/UserController.java
+++ b/user/src/main/java/com/example/user/controller/UserController.java
@@ -15,6 +15,7 @@ import com.example.user.service.UserService;
 import io.devground.core.model.web.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.mail.MessagingException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -27,7 +28,7 @@ public class UserController {
 
 	@Operation(summary = "인증메일 전송 API", description = "인증 메일을 전송합니다.")
 	@PostMapping("/send")
-	public BaseResponse<String> sendCertificateEmail(@RequestBody UserRequest userRequest) {
+	public BaseResponse<String> sendCertificateEmail(@RequestBody UserRequest userRequest) throws MessagingException {
 		userService.sendCertificateEmail(userRequest.email());
 
 		return BaseResponse.success(200, userRequest.email(), "인증메일 전송 성공");

--- a/user/src/main/java/com/example/user/service/UserService.java
+++ b/user/src/main/java/com/example/user/service/UserService.java
@@ -4,8 +4,10 @@ import com.example.user.model.dto.request.EmailCertificationRequest;
 import com.example.user.model.dto.request.UserRequest;
 import com.example.user.model.entity.User;
 
+import jakarta.mail.MessagingException;
+
 public interface UserService {
-	void sendCertificateEmail(String email);
+	void sendCertificateEmail(String email) throws MessagingException;
 
 	void checkCertificateEmail(EmailCertificationRequest emailCertificationRequest);
 

--- a/user/src/main/java/com/example/user/service/UserServiceImpl.java
+++ b/user/src/main/java/com/example/user/service/UserServiceImpl.java
@@ -19,6 +19,7 @@ import com.example.user.utils.provider.EmailProvider;
 import io.devground.core.events.user.UserCreatedEvent;
 import io.devground.core.events.user.UserDeletedEvent;
 import io.devground.core.model.vo.ErrorCode;
+import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,7 +41,7 @@ public class UserServiceImpl implements UserService {
 	private String userJoinCommandTopicName;
 
 	@Override
-	public void sendCertificateEmail(String email) {
+	public void sendCertificateEmail(String email) throws MessagingException {
 		String verificationCode = RandomStringUtils.randomAlphanumeric(10);
 
 		log.info("verificationCode:{}", verificationCode);

--- a/user/src/main/java/com/example/user/utils/provider/EmailProvider.java
+++ b/user/src/main/java/com/example/user/utils/provider/EmailProvider.java
@@ -12,6 +12,7 @@ import org.thymeleaf.context.Context;
 
 import com.example.user.service.RedisService;
 
+import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +26,7 @@ public class EmailProvider {
 	private final TemplateEngine templateEngine;
 	private final RedisService redisService;
 
-	public void sendEmail(String email, String verificationCode) {
+	public void sendEmail(String email, String verificationCode) throws MessagingException {
 		try {
 			redisService.save(email, verificationCode, Duration.ofMinutes(5));
 
@@ -49,6 +50,8 @@ public class EmailProvider {
 
 		} catch (Exception e) {
 			log.error(e.getMessage());
+
+			throw e;
 		}
 	}
 }

--- a/user/src/main/resources/application-stage.yml
+++ b/user/src/main/resources/application-stage.yml
@@ -1,10 +1,13 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/dbay_user?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://localhost:3307/dbay_user?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
     password: root1234
 
+  jpa:
+    hibernate:
+      ddl-auto: update
 
   data:
     redis:

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -2,10 +2,11 @@ server:
   port: 8082
 
 spring:
-
-
   profiles:
-    active: deploy
+    active: stage
+
+  config:
+    import: optional:classpath:env.properties
 
   mail:
     host: smtp.gmail.com
@@ -40,8 +41,6 @@ spring:
   kafka:
     bootstrap-servers:
       - kafka:9090
-
-
 
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
## 📌 PR 요약
### 1. 이메일 인증 예외 처리 중 에러를 던지지 않아 정상 흐름으로 진행되던 것 수정
### 2. 공통 yml 파일에서 env.properties 파일을 참조하지 않던 것 수정

## 🔍 관련 이슈
- close #189 

## 🧩 변경 사항
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 💡 참고 사항
- `try-catch` 로 예외를 잡아주시는 경우, 꼭 정상 흐름으로 변경해야하는 지 확인해주세요!!!
  - `catch` 에서 예외를 던져야 하는데 던지지 않고 마무리해버리면, 그 프로세스는 정상적으로 실행이 된 걸로 간주됩니다!