### PR TITLE
[FEAT] Product 모듈 상품 판매 처리

### DIFF
--- a/product/src/main/java/io/devground/product/application/model/CartProductsDto.java
+++ b/product/src/main/java/io/devground/product/application/model/CartProductsDto.java
@@ -1,0 +1,9 @@
+package io.devground.product.application.model;
+
+import java.util.List;
+
+public record CartProductsDto(
+
+	List<String> productCodes
+) {
+}

--- a/product/src/main/java/io/devground/product/application/model/ProductImageUrlsDto.java
+++ b/product/src/main/java/io/devground/product/application/model/ProductImageUrlsDto.java
@@ -1,0 +1,9 @@
+package io.devground.product.application.model;
+
+import java.util.List;
+
+public record ProductImageUrlsDto(
+
+	List<String> urls
+) {
+}

--- a/product/src/main/java/io/devground/product/application/model/RegistProductDto.java
+++ b/product/src/main/java/io/devground/product/application/model/RegistProductDto.java
@@ -1,0 +1,13 @@
+package io.devground.product.application.model;
+
+import java.util.List;
+
+public record RegistProductDto(
+
+	Long categoryId,
+	String title,
+	String description,
+	Long price,
+	List<String> imageExtensions
+) {
+}

--- a/product/src/main/java/io/devground/product/application/model/UpdateProductDto.java
+++ b/product/src/main/java/io/devground/product/application/model/UpdateProductDto.java
@@ -1,0 +1,13 @@
+package io.devground.product.application.model;
+
+import java.util.List;
+
+public record UpdateProductDto(
+
+	String title,
+	String description,
+	Long price,
+	List<String> deleteUrls,
+	List<String> newImageExtensions
+) {
+}

--- a/product/src/main/java/io/devground/product/application/model/UpdateProductSoldDto.java
+++ b/product/src/main/java/io/devground/product/application/model/UpdateProductSoldDto.java
@@ -1,0 +1,10 @@
+package io.devground.product.application.model;
+
+import io.devground.product.domain.vo.ProductSaleSpec;
+
+public record UpdateProductSoldDto(
+
+	String productCode,
+	ProductSaleSpec productSaleSpec
+) {
+}

--- a/product/src/main/java/io/devground/product/application/port/out/persistence/ProductPersistencePort.java
+++ b/product/src/main/java/io/devground/product/application/port/out/persistence/ProductPersistencePort.java
@@ -1,10 +1,13 @@
 package io.devground.product.application.port.out.persistence;
 
+import java.util.List;
+
+import io.devground.product.application.model.RegistProductDto;
+import io.devground.product.application.model.UpdateProductSoldDto;
 import io.devground.product.domain.model.Product;
 import io.devground.product.domain.vo.pagination.PageDto;
 import io.devground.product.domain.vo.pagination.PageQuery;
 import io.devground.product.domain.vo.response.GetAllProductsResponse;
-import io.devground.product.infrastructure.model.web.request.RegistProductRequest;
 
 public interface ProductPersistencePort {
 
@@ -12,7 +15,11 @@ public interface ProductPersistencePort {
 
 	Product getProductByCode(String code);
 
-	Product save(String sellerCode, RegistProductRequest request);
+	Product save(String sellerCode, RegistProductDto request);
 
 	void updateThumbnail(String productCode, String thumbnail);
+
+	List<Product> getProductsByCodes(String sellerCode, List<String> productCodes);
+
+	void updateToSold(List<UpdateProductSoldDto> updatedProductsInfo);
 }

--- a/product/src/main/java/io/devground/product/domain/model/ProductSale.java
+++ b/product/src/main/java/io/devground/product/domain/model/ProductSale.java
@@ -13,35 +13,47 @@ public class ProductSale {
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 
+	private String productCode;
 	private String sellerCode;
 
 	private ProductSaleSpec productSaleSpec;
 
 	private LocalDateTime soldAt;
 
-	public ProductSale(String sellerCode, ProductSaleSpec productSaleSpec) {
-		validate(sellerCode);
+	public ProductSale(String sellerCode, String productCode, ProductSaleSpec productSaleSpec) {
+		validate(sellerCode, productCode);
 
 		this.code = DomainUtils.generateCode();
 
 		this.createdAt = LocalDateTime.now();
 		this.updatedAt = LocalDateTime.now();
 
+		this.productCode = productCode;
 		this.sellerCode = sellerCode;
 		this.productSaleSpec = productSaleSpec;
 	}
 
+	public void updateToSold(ProductSaleSpec productSaleSpec) {
+		this.productSaleSpec = productSaleSpec;
+		this.updateSoldComplete();
+	}
+
 	public void updateSoldComplete() {
 		this.soldAt = LocalDateTime.now();
+		this.updateClock();
 	}
 
 	public void updateClock() {
 		this.updatedAt = LocalDateTime.now();
 	}
 
-	private void validate(String sellerCode) {
+	private void validate(String sellerCode, String productCode) {
 		if (sellerCode == null || sellerCode.isBlank()) {
 			DomainErrorCode.SELLER_CODE_MUST_BE_INPUT.throwException();
+		}
+
+		if (productCode == null || productCode.isBlank()) {
+			DomainErrorCode.PRODUCT_CODE_MUST_BE_INPUT.throwException();
 		}
 	}
 
@@ -55,6 +67,10 @@ public class ProductSale {
 
 	public LocalDateTime getUpdatedAt() {
 		return updatedAt;
+	}
+
+	public String getProductCode() {
+		return productCode;
 	}
 
 	public String getSellerCode() {

--- a/product/src/main/java/io/devground/product/domain/port/in/ProductUseCase.java
+++ b/product/src/main/java/io/devground/product/domain/port/in/ProductUseCase.java
@@ -2,6 +2,10 @@ package io.devground.product.domain.port.in;
 
 import java.util.List;
 
+import io.devground.product.application.model.CartProductsDto;
+import io.devground.product.application.model.ProductImageUrlsDto;
+import io.devground.product.application.model.RegistProductDto;
+import io.devground.product.application.model.UpdateProductDto;
 import io.devground.product.domain.vo.pagination.PageDto;
 import io.devground.product.domain.vo.pagination.PageQuery;
 import io.devground.product.domain.vo.response.CartProductsResponse;
@@ -9,26 +13,22 @@ import io.devground.product.domain.vo.response.GetAllProductsResponse;
 import io.devground.product.domain.vo.response.ProductDetailResponse;
 import io.devground.product.domain.vo.response.RegistProductResponse;
 import io.devground.product.domain.vo.response.UpdateProductResponse;
-import io.devground.product.infrastructure.model.web.request.CartProductsRequest;
-import io.devground.product.infrastructure.model.web.request.ProductImageUrlsRequest;
-import io.devground.product.infrastructure.model.web.request.RegistProductRequest;
-import io.devground.product.infrastructure.model.web.request.UpdateProductRequest;
 
 public interface ProductUseCase {
 
 	PageDto<GetAllProductsResponse> getProducts(PageQuery pageRequest);
 
-	RegistProductResponse registProduct(String sellerCode, RegistProductRequest request);
+	RegistProductResponse registProduct(String sellerCode, RegistProductDto request);
 
-	Void saveImageUrls(String sellerCode, String productCode, ProductImageUrlsRequest request);
+	Void saveImageUrls(String sellerCode, String productCode, ProductImageUrlsDto request);
 
 	ProductDetailResponse getProductDetail(String productCode);
 
-	UpdateProductResponse updateProduct(String sellerCode, String productCode, UpdateProductRequest request);
+	UpdateProductResponse updateProduct(String sellerCode, String productCode, UpdateProductDto request);
 
 	Void deleteProduct(String sellerCode, String productCode);
 
-	List<CartProductsResponse> getCartProducts(CartProductsRequest request);
+	List<CartProductsResponse> getCartProducts(CartProductsDto request);
 
-	void updateStatusToSold(String sellerCode, CartProductsRequest request);
+	void updateStatusToSold(String sellerCode, CartProductsDto request);
 }

--- a/product/src/main/java/io/devground/product/domain/vo/DomainErrorCode.java
+++ b/product/src/main/java/io/devground/product/domain/vo/DomainErrorCode.java
@@ -17,6 +17,7 @@ public enum DomainErrorCode {
 	PRICE_MUST_BE_INPUT(400, "상품 가격은 반드시 입력되어야 합니다."),
 	PRICE_MUST_BE_POSITIVE(400, "상품 가격은 반드시 양수여야 합니다."),
 	SELLER_CODE_MUST_BE_INPUT(400, "판매자 코드는 반드시 입력되어야 합니다."),
+	PRODUCT_CODE_MUST_BE_INPUT(400, "상품 코드는 반드시 입력되어야 합니다."),
 
 	// category
 	CANNOT_EXCEED_MAX_DEPTH(400, "카테고리는 최대 뎁스를 초과할 수 없습니다."),

--- a/product/src/main/java/io/devground/product/infrastructure/adapter/in/web/ProductApiController.java
+++ b/product/src/main/java/io/devground/product/infrastructure/adapter/in/web/ProductApiController.java
@@ -16,6 +16,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.devground.core.model.web.BaseResponse;
+import io.devground.product.application.model.CartProductsDto;
+import io.devground.product.application.model.ProductImageUrlsDto;
+import io.devground.product.application.model.RegistProductDto;
+import io.devground.product.application.model.UpdateProductDto;
 import io.devground.product.domain.port.in.ProductUseCase;
 import io.devground.product.domain.vo.pagination.PageDto;
 import io.devground.product.domain.vo.pagination.PageQuery;
@@ -61,9 +65,17 @@ public class ProductApiController {
 		@RequestHeader("X-CODE") String sellerCode
 	) {
 
+		RegistProductDto requestDto = new RegistProductDto(
+			request.categoryId(),
+			request.title(),
+			request.description(),
+			request.price(),
+			request.imageExtensions()
+		);
+
 		return BaseResponse.success(
 			CREATED.value(),
-			productApplication.registProduct(sellerCode, request),
+			productApplication.registProduct(sellerCode, requestDto),
 			"상품이 성공적으로 등록되었습니다."
 		);
 	}
@@ -76,9 +88,11 @@ public class ProductApiController {
 		@RequestHeader("X-CODE") String sellerCode
 	) {
 
+		ProductImageUrlsDto requestDto = new ProductImageUrlsDto(request.urls());
+
 		return BaseResponse.success(
 			NO_CONTENT.value(),
-			productApplication.saveImageUrls(sellerCode, productCode, request),
+			productApplication.saveImageUrls(sellerCode, productCode, requestDto),
 			"상품 이미지가 성공적으로 등록되었습니다."
 		);
 	}
@@ -106,9 +120,13 @@ public class ProductApiController {
 		@RequestHeader(name = "X-CODE") String sellerCode
 	) {
 
+		UpdateProductDto requestDto = new UpdateProductDto(
+			request.title(), request.description(), request.price(), request.deleteUrls(), request.newImageExtensions()
+		);
+
 		return BaseResponse.success(
 			OK.value(),
-			productApplication.updateProduct(sellerCode, productCode, request),
+			productApplication.updateProduct(sellerCode, productCode, requestDto),
 			"상품 정보가 성공적으로 수정되었습니다."
 		);
 	}
@@ -134,9 +152,11 @@ public class ProductApiController {
 		@RequestBody CartProductsRequest request
 	) {
 
+		CartProductsDto requestDto = new CartProductsDto(request.productCodes());
+
 		return BaseResponse.success(
 			OK.value(),
-			productApplication.getCartProducts(request),
+			productApplication.getCartProducts(requestDto),
 			"장바구니의 상품 정보들을 성공적으로 불러왔습니다."
 		);
 	}
@@ -149,6 +169,8 @@ public class ProductApiController {
 		@RequestBody CartProductsRequest request
 	) {
 
-		productApplication.updateStatusToSold(sellerCode, request);
+		CartProductsDto requestDto = new CartProductsDto(request.productCodes());
+
+		productApplication.updateStatusToSold(sellerCode, requestDto);
 	}
 }

--- a/product/src/main/java/io/devground/product/infrastructure/adapter/out/ProductJpaRepository.java
+++ b/product/src/main/java/io/devground/product/infrastructure/adapter/out/ProductJpaRepository.java
@@ -27,14 +27,21 @@ public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long>
 			ps.price
 		)
 		FROM ProductEntity p
-		JOIN p.productSale ps
+		JOIN FETCH p.productSale ps
 		WHERE p.code IN :productCodes
 		AND ps.productStatus = 'ON_SALE'
 		"""
 	)
 	List<CartProductsResponse> findCartProductsByProductCodes(@Param("productCodes") List<String> productCodes);
 
-	List<ProductEntity> findAllByCodeIn(List<String> codes);
+	@Query("""
+		SELECT p
+		FROM ProductEntity p
+		JOIN FETCH p.productSale ps
+		WHERE p.deleteStatus = 'N'
+		AND p.code IN :productCodes
+		""")
+	List<ProductEntity> findProductsByCodes(List<String> codes);
 
 	@Query(
 		value = """

--- a/product/src/main/java/io/devground/product/infrastructure/adapter/out/ProductPersistenceAdapter.java
+++ b/product/src/main/java/io/devground/product/infrastructure/adapter/out/ProductPersistenceAdapter.java
@@ -1,12 +1,17 @@
 package io.devground.product.infrastructure.adapter.out;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import io.devground.product.application.model.RegistProductDto;
+import io.devground.product.application.model.UpdateProductSoldDto;
 import io.devground.product.application.port.out.persistence.ProductPersistencePort;
 import io.devground.product.domain.model.Product;
 import io.devground.product.domain.vo.DomainErrorCode;
+import io.devground.product.domain.vo.ProductSaleSpec;
 import io.devground.product.domain.vo.pagination.PageDto;
 import io.devground.product.domain.vo.pagination.PageQuery;
 import io.devground.product.domain.vo.response.GetAllProductsResponse;
@@ -15,7 +20,6 @@ import io.devground.product.infrastructure.mapper.ProductMapper;
 import io.devground.product.infrastructure.model.persistence.CategoryEntity;
 import io.devground.product.infrastructure.model.persistence.ProductEntity;
 import io.devground.product.infrastructure.model.persistence.ProductSaleEntity;
-import io.devground.product.infrastructure.model.web.request.RegistProductRequest;
 import io.devground.product.infrastructure.util.PageUtils;
 import lombok.RequiredArgsConstructor;
 
@@ -43,14 +47,13 @@ public class ProductPersistenceAdapter implements ProductPersistencePort {
 	@Override
 	public Product getProductByCode(String code) {
 
-		ProductEntity product = productRepository.findByCode(code)
-			.orElseThrow(DomainErrorCode.PRODUCT_NOT_FOUND::throwException);
+		ProductEntity product = getProduct(code);
 
 		return ProductMapper.toProductDomain(product, product.getProductSale());
 	}
 
 	@Override
-	public Product save(String sellerCode, RegistProductRequest request) {
+	public Product save(String sellerCode, RegistProductDto request) {
 
 		CategoryEntity categoryEntity = categoryRepository.findById(request.categoryId())
 			.orElseThrow(DomainErrorCode.CATEGORY_NOT_FOUND::throwException);
@@ -79,9 +82,42 @@ public class ProductPersistenceAdapter implements ProductPersistencePort {
 	@Override
 	public void updateThumbnail(String productCode, String thumbnail) {
 
-		ProductEntity product = productRepository.findByCode(productCode)
-			.orElseThrow(DomainErrorCode.PRODUCT_NOT_FOUND::throwException);
+		ProductEntity product = getProduct(productCode);
 
 		product.updateThumbnail(thumbnail);
+	}
+
+	@Override
+	public List<Product> getProductsByCodes(String sellerCode, List<String> productCodes) {
+
+		List<ProductEntity> products = this.getProducts(productCodes);
+
+		return products.stream()
+			.map(p -> ProductMapper.toProductDomain(p, p.getProductSale()))
+			.toList();
+	}
+
+	@Override
+	public void updateToSold(List<UpdateProductSoldDto> updateProductsInfo) {
+
+		updateProductsInfo.forEach(p -> {
+				ProductEntity product = getProduct(p.productCode());
+				ProductSaleEntity productSale = product.getProductSale();
+
+				ProductSaleSpec updatedSpec = p.productSaleSpec();
+
+				productSale.changeSoldSpec(updatedSpec.price(), updatedSpec.productStatus());
+			}
+		);
+	}
+
+	private ProductEntity getProduct(String code) {
+		return productRepository.findByCode(code)
+			.orElseThrow(DomainErrorCode.PRODUCT_NOT_FOUND::throwException);
+	}
+
+	private List<ProductEntity> getProducts(List<String> productCodes) {
+
+		return productRepository.findProductsByCodes(productCodes);
 	}
 }

--- a/product/src/main/java/io/devground/product/infrastructure/mapper/ProductMapper.java
+++ b/product/src/main/java/io/devground/product/infrastructure/mapper/ProductMapper.java
@@ -18,16 +18,17 @@ public class ProductMapper {
 			CategoryMapper.toDomain(productEntity.getCategory())
 		);
 
-		product.linkProductSale(toProductSaleDomain(productSaleEntity));
+		product.linkProductSale(toProductSaleDomain(productEntity, productSaleEntity));
 		product.updateId(productEntity.getId());
 
 		return product;
 	}
 
-	public ProductSale toProductSaleDomain(ProductSaleEntity productSaleEntity) {
+	public ProductSale toProductSaleDomain(ProductEntity productEntity, ProductSaleEntity productSaleEntity) {
 
 		return new ProductSale(
 			productSaleEntity.getSellerCode(),
+			productEntity.getCode(),
 			new ProductSaleSpec(productSaleEntity.getPrice(), productSaleEntity.getProductStatus())
 		);
 	}

--- a/product/src/main/java/io/devground/product/infrastructure/model/persistence/ProductSaleEntity.java
+++ b/product/src/main/java/io/devground/product/infrastructure/model/persistence/ProductSaleEntity.java
@@ -68,13 +68,17 @@ public class ProductSaleEntity extends BaseEntity {
 		product.addProductSale(this);
 	}
 
-	public void changeAsSold() {
+	public void changeSoldSpec(Long price, ProductStatus productStatus) {
 		if (isSold()) {
 			DomainErrorCode.ONLY_ON_SALE_PRODUCT_CHANGEABLE.throwException();
 		}
 
-		this.productStatus = ProductStatus.SOLD;
-		this.soldAt = LocalDateTime.now();
+		this.price = price;
+		this.productStatus = productStatus;
+
+		if (productStatus == ProductStatus.SOLD) {
+			this.soldAt = LocalDateTime.now();
+		}
 	}
 
 	public void changePrice(Long price) {


### PR DESCRIPTION
## 📌 PR 요약
### 1. infra 단에서 받는 Request를 Application에서 사용할 수 있는 Request로 매핑하는 작업 추가
- `infra` 단에서 사용하는 `RequestDTO` 는 객체는 **스프링**의 `validation` 사용
- 따라서 `application` 단에서 받아서 사용할 수 있도록 `DTO` 를 하나 더 생성하여 매핑 처리

## 🔍 관련 이슈
- close #230 

## 🧩 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 💡 참고 사항
- `Product` 모듈 상품 판매 처리를 완료하였습니다.
- 기존 `infra` 단에서 사용하던 `DTO` 의 경우 `validation` 을 의존하고 있기 때문에,  `application` 단에서 사용할 `DTO` 를 별도로 생성한 후 매핑 작업을 처리해주었습니다.