### PR TITLE
[FIX] 잘못된 JPQL 수정 및 상품 판매 완료 처리 파라미터 변경

### DIFF
--- a/product/src/main/java/io/devground/product/application/model/UpdateProductSoldDto.java
+++ b/product/src/main/java/io/devground/product/application/model/UpdateProductSoldDto.java
@@ -1,10 +1,10 @@
 package io.devground.product.application.model;
 
-import io.devground.product.domain.vo.ProductSaleSpec;
+import io.devground.product.domain.vo.ProductStatus;
 
 public record UpdateProductSoldDto(
 
 	String productCode,
-	ProductSaleSpec productSaleSpec
+	ProductStatus productStatus
 ) {
 }

--- a/product/src/main/java/io/devground/product/application/service/ProductApplicationService.java
+++ b/product/src/main/java/io/devground/product/application/service/ProductApplicationService.java
@@ -143,11 +143,13 @@ public class ProductApplicationService implements ProductUseCase {
 
 		for (ProductSale productSale : productSales) {
 			Long price = productSale.getProductSaleSpec().price();
-			productSale.updateToSold(new ProductSaleSpec(price, ProductStatus.SOLD));
+			ProductSaleSpec updatedSaleSpec = new ProductSaleSpec(price, ProductStatus.SOLD);
+
+			productSale.updateToSold(updatedSaleSpec);
 
 			updatedProductsInfo.add(new UpdateProductSoldDto(
 				productSale.getProductCode(),
-				productSale.getProductSaleSpec()
+				updatedSaleSpec.productStatus()
 			));
 		}
 

--- a/product/src/main/java/io/devground/product/infrastructure/adapter/out/ProductJpaRepository.java
+++ b/product/src/main/java/io/devground/product/infrastructure/adapter/out/ProductJpaRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import io.devground.product.domain.model.Product;
+import io.devground.product.domain.vo.ProductStatus;
 import io.devground.product.domain.vo.response.CartProductsResponse;
 import io.devground.product.infrastructure.model.persistence.ProductEntity;
 
@@ -27,12 +27,15 @@ public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long>
 			ps.price
 		)
 		FROM ProductEntity p
-		JOIN FETCH p.productSale ps
+		JOIN p.productSale ps
 		WHERE p.code IN :productCodes
-		AND ps.productStatus = 'ON_SALE'
+		AND ps.productStatus = :status
 		"""
 	)
-	List<CartProductsResponse> findCartProductsByProductCodes(@Param("productCodes") List<String> productCodes);
+	List<CartProductsResponse> findCartProductsByProductCodes(
+		@Param("productCodes") List<String> productCodes,
+		@Param("status") ProductStatus status
+	);
 
 	@Query("""
 		SELECT p
@@ -41,7 +44,7 @@ public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long>
 		WHERE p.deleteStatus = 'N'
 		AND p.code IN :productCodes
 		""")
-	List<ProductEntity> findProductsByCodes(List<String> codes);
+	List<ProductEntity> findProductsByCodes(@Param("productCodes") List<String> productCodes);
 
 	@Query(
 		value = """
@@ -70,5 +73,5 @@ public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long>
 			FROM ProductEntity p
 			"""
 	)
-	Page<Product> findAllWithCategories(Pageable pageable);
+	Page<ProductEntity> findAllWithCategories(Pageable pageable);
 }

--- a/product/src/main/java/io/devground/product/infrastructure/adapter/out/ProductPersistenceAdapter.java
+++ b/product/src/main/java/io/devground/product/infrastructure/adapter/out/ProductPersistenceAdapter.java
@@ -11,7 +11,6 @@ import io.devground.product.application.model.UpdateProductSoldDto;
 import io.devground.product.application.port.out.persistence.ProductPersistencePort;
 import io.devground.product.domain.model.Product;
 import io.devground.product.domain.vo.DomainErrorCode;
-import io.devground.product.domain.vo.ProductSaleSpec;
 import io.devground.product.domain.vo.pagination.PageDto;
 import io.devground.product.domain.vo.pagination.PageQuery;
 import io.devground.product.domain.vo.response.GetAllProductsResponse;
@@ -104,9 +103,7 @@ public class ProductPersistenceAdapter implements ProductPersistencePort {
 				ProductEntity product = getProduct(p.productCode());
 				ProductSaleEntity productSale = product.getProductSale();
 
-				ProductSaleSpec updatedSpec = p.productSaleSpec();
-
-				productSale.changeSoldSpec(updatedSpec.price(), updatedSpec.productStatus());
+				productSale.updateProductStatus(p.productStatus());
 			}
 		);
 	}

--- a/product/src/main/java/io/devground/product/infrastructure/model/persistence/ProductSaleEntity.java
+++ b/product/src/main/java/io/devground/product/infrastructure/model/persistence/ProductSaleEntity.java
@@ -27,8 +27,8 @@ import lombok.NoArgsConstructor;
 @Table(
 	indexes = {
 		@Index(
-			name = "idx_product_sale_seller_status_created",
-			columnList = "sellerCode, productStatus, createdAt"
+			name = "idx_product_sale_status_seller_created",
+			columnList = "productStatus, sellerCode, createdAt"
 		)
 	}
 )
@@ -68,12 +68,11 @@ public class ProductSaleEntity extends BaseEntity {
 		product.addProductSale(this);
 	}
 
-	public void changeSoldSpec(Long price, ProductStatus productStatus) {
+	public void updateProductStatus(ProductStatus productStatus) {
 		if (isSold()) {
 			DomainErrorCode.ONLY_ON_SALE_PRODUCT_CHANGEABLE.throwException();
 		}
 
-		this.price = price;
 		this.productStatus = productStatus;
 
 		if (productStatus == ProductStatus.SOLD) {


### PR DESCRIPTION
## 📌 PR 요약
### 1. 잘못된 JQPL들 수정
### 2. 상품 판매 완료 처리의 파라미터를 ProductStatus만 넣도록 변경

## 🧩 변경 사항
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 💡 참고 사항
- 기존 `JPQL` 을 잘못 작성하여 생긴 버그를 수정하였습니다.
- 상품 판매 완료 처리 기능의 파라미터를 `ProductStatus` 만 사용하도록 변경하였습니다.