### PR TITLE
[FEAT] Product 모듈의 상품 삭제 구현

### DIFF
--- a/product/src/main/java/io/devground/product/ProductApplication.java
+++ b/product/src/main/java/io/devground/product/ProductApplication.java
@@ -3,6 +3,7 @@ package io.devground.product;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -10,6 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableAsync
 @EnableKafka
 @EnableScheduling
+@EnableJpaAuditing
 @EnableFeignClients
 @SpringBootApplication
 public class ProductApplication {

--- a/product/src/main/java/io/devground/product/application/port/out/ProductEventPort.java
+++ b/product/src/main/java/io/devground/product/application/port/out/ProductEventPort.java
@@ -1,0 +1,12 @@
+package io.devground.product.application.port.out;
+
+import io.devground.product.domain.model.Product;
+
+public interface ProductEventPort {
+
+	void publishCreated(Product product);
+
+	void publishUpdated(Product product);
+
+	void publishDeleted(Product product);
+}

--- a/product/src/main/java/io/devground/product/application/port/out/ProductOrchestrationPort.java
+++ b/product/src/main/java/io/devground/product/application/port/out/ProductOrchestrationPort.java
@@ -14,4 +14,6 @@ public interface ProductOrchestrationPort {
 	void handleImageProcessFailure(String sagaId, ImageProcessedEvent event);
 
 	List<URL> updateProductImages(String productCode, List<String> deleteUrls, List<String> newExtensions);
+
+	void deleteProductImages(String productCode);
 }

--- a/product/src/main/java/io/devground/product/application/port/out/persistence/ProductPersistencePort.java
+++ b/product/src/main/java/io/devground/product/application/port/out/persistence/ProductPersistencePort.java
@@ -25,4 +25,6 @@ public interface ProductPersistencePort {
 	void updateToSold(UpdateProductSoldDto updatedProductsSoldDto);
 
 	void updateProduct(String sellerCode, Product product, ProductSale productSale);
+
+	void deleteProduct(String sellerCode, Product product);
 }

--- a/product/src/main/java/io/devground/product/application/port/out/persistence/ProductSearchPort.java
+++ b/product/src/main/java/io/devground/product/application/port/out/persistence/ProductSearchPort.java
@@ -7,4 +7,6 @@ public interface ProductSearchPort {
 	void prepareSearch(Product product);
 
 	void updateSearch(Product product);
+
+	void deleteSearch(Product product);
 }

--- a/product/src/main/java/io/devground/product/domain/port/in/ProductUseCase.java
+++ b/product/src/main/java/io/devground/product/domain/port/in/ProductUseCase.java
@@ -31,4 +31,6 @@ public interface ProductUseCase {
 	List<CartProductsResponse> getCartProducts(CartProductsDto request);
 
 	void updateStatusToSold(String sellerCode, CartProductsDto request);
+
+	void updateThumbnail(String productCode, String thumbnail);
 }

--- a/product/src/main/java/io/devground/product/infrastructure/adapter/in/ProductEventListener.java
+++ b/product/src/main/java/io/devground/product/infrastructure/adapter/in/ProductEventListener.java
@@ -1,0 +1,36 @@
+package io.devground.product.infrastructure.adapter.in;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import io.devground.product.application.port.out.persistence.ProductSearchPort;
+import io.devground.product.infrastructure.model.vo.ProductCreateEvent;
+import io.devground.product.infrastructure.model.vo.ProductDeleteEvent;
+import io.devground.product.infrastructure.model.vo.ProductUpdateEvent;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProductEventListener {
+
+	private final ProductSearchPort searchPort;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleProductDocumentIndex(ProductCreateEvent event) {
+
+		searchPort.prepareSearch(event.product());
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleProductUpdateIndex(ProductUpdateEvent event) {
+
+		searchPort.updateSearch(event.product());
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleProductDocumentDelete(ProductDeleteEvent event) {
+
+		searchPort.deleteSearch(event.product());
+	}
+}

--- a/product/src/main/java/io/devground/product/infrastructure/adapter/in/kafka/ProductKafkaListener.java
+++ b/product/src/main/java/io/devground/product/infrastructure/adapter/in/kafka/ProductKafkaListener.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import io.devground.core.event.image.ImageProcessedEvent;
 import io.devground.product.application.port.out.ProductOrchestrationPort;
-import io.devground.product.application.service.ProductApplicationService;
+import io.devground.product.domain.port.in.ProductUseCase;
 import io.devground.product.infrastructure.saga.entity.Saga;
 import io.devground.product.infrastructure.saga.service.SagaService;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ProductKafkaListener {
 
 	private final ProductOrchestrationPort orchestrator;
-	private final ProductApplicationService productApplication;
+	private final ProductUseCase productApplication;
 	private final SagaService sagaService;
 
 	@KafkaHandler

--- a/product/src/main/java/io/devground/product/infrastructure/adapter/out/ProductEventAdapter.java
+++ b/product/src/main/java/io/devground/product/infrastructure/adapter/out/ProductEventAdapter.java
@@ -1,0 +1,36 @@
+package io.devground.product.infrastructure.adapter.out;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import io.devground.product.application.port.out.ProductEventPort;
+import io.devground.product.domain.model.Product;
+import io.devground.product.infrastructure.model.vo.ProductCreateEvent;
+import io.devground.product.infrastructure.model.vo.ProductDeleteEvent;
+import io.devground.product.infrastructure.model.vo.ProductUpdateEvent;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProductEventAdapter implements ProductEventPort {
+
+	private final ApplicationEventPublisher publisher;
+
+	@Override
+	public void publishCreated(Product product) {
+
+		publisher.publishEvent(new ProductCreateEvent(product));
+	}
+
+	@Override
+	public void publishUpdated(Product product) {
+
+		publisher.publishEvent(new ProductUpdateEvent(product));
+	}
+
+	@Override
+	public void publishDeleted(Product product) {
+
+		publisher.publishEvent(new ProductDeleteEvent(product));
+	}
+}

--- a/product/src/main/java/io/devground/product/infrastructure/adapter/out/ProductPersistenceAdapter.java
+++ b/product/src/main/java/io/devground/product/infrastructure/adapter/out/ProductPersistenceAdapter.java
@@ -123,6 +123,18 @@ public class ProductPersistenceAdapter implements ProductPersistencePort {
 		productSaleEntity.changePrice(productSale.getProductSaleSpec().price());
 	}
 
+	@Override
+	public void deleteProduct(String sellerCode, Product product) {
+
+		ProductEntity productEntity = getProduct(product.getCode());
+
+		if (!productEntity.getProductSale().getSellerCode().equals(sellerCode)) {
+			ErrorCode.IS_NOT_PRODUCT_OWNER.throwServiceException();
+		}
+
+		productEntity.delete();
+	}
+
 	private ProductEntity getProduct(String code) {
 		return productRepository.findByCode(code)
 			.orElseThrow(DomainErrorCode.PRODUCT_NOT_FOUND::throwException);

--- a/product/src/main/java/io/devground/product/infrastructure/adapter/out/client/ProductEsAdapter.java
+++ b/product/src/main/java/io/devground/product/infrastructure/adapter/out/client/ProductEsAdapter.java
@@ -35,6 +35,13 @@ public class ProductEsAdapter implements ProductSearchPort {
 		this.indexProduct(product);
 	}
 
+	@Override
+	@Async("esTaskExecutor")
+	public void deleteSearch(Product product) {
+
+		this.indexProduct(product);
+	}
+
 	private void indexProduct(Product product) {
 
 		String productCode = product.getCode();

--- a/product/src/main/java/io/devground/product/infrastructure/model/vo/ProductCreateEvent.java
+++ b/product/src/main/java/io/devground/product/infrastructure/model/vo/ProductCreateEvent.java
@@ -1,0 +1,9 @@
+package io.devground.product.infrastructure.model.vo;
+
+import io.devground.product.domain.model.Product;
+
+public record ProductCreateEvent(
+
+	Product product
+) {
+}

--- a/product/src/main/java/io/devground/product/infrastructure/model/vo/ProductDeleteEvent.java
+++ b/product/src/main/java/io/devground/product/infrastructure/model/vo/ProductDeleteEvent.java
@@ -1,0 +1,9 @@
+package io.devground.product.infrastructure.model.vo;
+
+import io.devground.product.domain.model.Product;
+
+public record ProductDeleteEvent(
+
+	Product product
+) {
+}

--- a/product/src/main/java/io/devground/product/infrastructure/model/vo/ProductUpdateEvent.java
+++ b/product/src/main/java/io/devground/product/infrastructure/model/vo/ProductUpdateEvent.java
@@ -1,0 +1,9 @@
+package io.devground.product.infrastructure.model.vo;
+
+import io.devground.product.domain.model.Product;
+
+public record ProductUpdateEvent(
+
+	Product product
+) {
+}

--- a/src/main/java/io/devground/dbay/domain/product/product/infra/kafka/ProductKafkaListener.java
+++ b/src/main/java/io/devground/dbay/domain/product/product/infra/kafka/ProductKafkaListener.java
@@ -30,8 +30,7 @@ public class ProductKafkaListener {
 
 		String sagaId = event.sagaId();
 
-		log.info("이미지 처리 결과 수신 - SagaId: {}, ProductCode: {}, isSuccess: {}",
-			sagaId, event.referenceCode(), event.isSuccess());
+		log.info("이미지 처리 결과 수신");
 
 		// 외부에서 직접 Image API 호출한 경우
 		if (sagaId == null) {
@@ -42,8 +41,7 @@ public class ProductKafkaListener {
 		Saga saga = sagaService.getSaga(sagaId);
 
 		if (saga.getSagaStatus().isTerminal()) {
-			log.warn("이미 종료된 Saga - SagaId: {}, ProductCode: {}, Step: {}",
-				sagaId, event.referenceCode(), saga.getCurrentStep());
+			log.warn("이미 종료된 Saga");
 
 			return;
 		}


### PR DESCRIPTION
## 📌 PR 요약
### 1. 기존 코드에 잔재했던 불필요한 변수들 제거
### 2. 기존 Elasticsearch 인덱싱 작업에서, 트랜잭션을 고려하지 않았던 부분 수정
- 기존 방식대로 하면 인덱싱 작업은 **비동기**이기 때문에, 롤백 시 정합성 문제 발생 가능성 존재
- 이벤트리스너와 `TransactionPhase.AFTER_COMMIT` 조합을 통해, 트랜잭션이 완료된 상황에서만 인덱싱 작업을 진행하도록 수정
- 해당 방식으로 **DB 의 데이터**와 **ES Document** 간의 정합성 문제 해결
- 상품 등록, 수정 부분에 해당 수정 반영
### 3. Product 모듈 삭제 구현
- 인덱싱에는 이벤트리스너 방식을 사용
- 상품 삭제, 인덱싱, 이미지 삭제 총 3가지 흐름으로 구현
### 4. 기존 일부 에러 수정
- 인자 순서를 잘못 넘겨주던 부분 수정

## 🔍 관련 이슈
- close #237 

## 🧩 변경 사항
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 💡 참고 사항
- 기존 엘라스틱서치 인덱싱 작업을 롤백 상황을 고려하여 수정하였습니다.
  - 이벤트리스너와 `TranscationPhase.AFTER_COMMIT` 조합을 사용하였습니다.
- 상품 삭제 기능을 구현하였습니다.
- 기존, 인자 순서 착오로 인해 기능이 잘못 동작하던 버그를 수정하였습니다.