### PR TITLE
[FIX] 빈 이미지 확장자 허가 및 상품 상세 조회 시 X-CODE의 required를 false 로 지정

### DIFF
--- a/product/src/main/java/io/devground/product/image/application/util/ImageUtil.java
+++ b/product/src/main/java/io/devground/product/image/application/util/ImageUtil.java
@@ -11,7 +11,7 @@ import lombok.experimental.UtilityClass;
 public class ImageUtil {
 
 	private static final List<String> ALLOWED_IMAGE_EXTENSIONS = List.of(
-		"jpg", "jpeg", "png", "gif", "webp", "bmp", "svg"
+		"", "jpg", "jpeg", "png", "gif", "webp", "bmp", "svg"
 	);
 
 	public String buildS3Key(ImageType imageType, String referenceCode, String fileExtension) {

--- a/product/src/main/java/io/devground/product/product/infrastructure/adapter/in/web/ProductApiController.java
+++ b/product/src/main/java/io/devground/product/product/infrastructure/adapter/in/web/ProductApiController.java
@@ -115,7 +115,7 @@ public class ProductApiController {
 	@Operation(summary = "상품 상세 조회", description = "상품의 상세 정보를 조회할 수 있습니다.")
 	public BaseResponse<ProductDetailResponse> getProductDetail(
 		@PathVariable String productCode,
-		@RequestHeader("X-CODE") String userCode
+		@RequestHeader(name = "X-CODE", required = false) String userCode
 	) {
 
 		return BaseResponse.success(


### PR DESCRIPTION
## 📌 PR 요약
### 1. 빈 이미지 확장자 허가 (이미지 미등록)
### 2. X-CODE의 required를 false로 지정

## 🧩 변경 사항
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 💡 참고 사항
### 1. 빈 이미지 확장자를 허가하여 이미지를 미등록해도 상관없도록 수정하였습니다.<br><br>
### 2. X-CODE의 `required` 를 `false` 로 지정하였습니다.