### PR TITLE
[FIX] 상품 등록, 수정에서 이미지 등록을 하지 않을 시 PresignedUrl 발급을 하지 않도록 수정

### DIFF
--- a/product/src/main/java/io/devground/product/product/application/service/ProductApplicationService.java
+++ b/product/src/main/java/io/devground/product/product/application/service/ProductApplicationService.java
@@ -78,7 +78,13 @@ public class ProductApplicationService implements ProductUseCase {
 		List<String> imageExtensions = request.imageExtensions();
 		List<URL> presignedUrls = new ArrayList<>();
 		if (imageExtensions != null && !imageExtensions.isEmpty()) {
-			presignedUrls = imagePort.prepareUploadUrls(ImageType.PRODUCT, productCode, imageExtensions);
+			List<String> validExtensions = imageExtensions.stream()
+				.filter(extension -> extension != null && !extension.isBlank())
+				.toList();
+
+			if (!validExtensions.isEmpty()) {
+				presignedUrls = imagePort.prepareUploadUrls(ImageType.PRODUCT, productCode, imageExtensions);
+			}
 		}
 
 		return new RegistProductResponse(product, productSale, presignedUrls);

--- a/product/src/main/java/io/devground/product/product/infrastructure/adapter/out/ProductOrchestrator.java
+++ b/product/src/main/java/io/devground/product/product/infrastructure/adapter/out/ProductOrchestrator.java
@@ -112,7 +112,19 @@ public class ProductOrchestrator implements ProductOrchestrationPort {
 		try {
 			List<URL> updatedPresignedUrls = new ArrayList<>();
 
-			if (!CollectionUtils.isEmpty(deleteUrls) || !CollectionUtils.isEmpty(newExtensions)) {
+			boolean hasValidDeleteUrls = deleteUrls != null && !deleteUrls.isEmpty()
+				&& deleteUrls.stream().anyMatch(url -> url != null && !url.isBlank());
+
+			List<String> validNewExtensions = null;
+			if (newExtensions != null && !newExtensions.isEmpty()) {
+				validNewExtensions = newExtensions.stream()
+					.filter(extension -> extension != null && !extension.isBlank())
+					.toList();
+			}
+
+			boolean hasValidNewExtensions = validNewExtensions != null && !validNewExtensions.isEmpty();
+
+			if (hasValidDeleteUrls || hasValidNewExtensions) {
 				updatedPresignedUrls = imagePort.updateImages(PRODUCT, productCode, deleteUrls, newExtensions);
 			}
 


### PR DESCRIPTION
## 📌 PR 요약
### 1. 상품 등록, 수정에서 이미지 미등록 시 PresignedUrl 미발급

## 🧩 변경 사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 💡 참고 사항
### 1. 상품 등록, 수정에서 이미지 미등록 시 PresignedUrl 발급 요청 자체를 보내지 않도록 수정하였습니다.
  - `OpenFeign` 요청 한 번을 줄입니다.